### PR TITLE
LTI-56: xml_config should be available at all times not only on DEV mode

### DIFF
--- a/app/controllers/tool_profile_controller.rb
+++ b/app/controllers/tool_profile_controller.rb
@@ -25,10 +25,6 @@ class ToolProfileController < ApplicationController
 
   # show xml builder for customization in tool consumer url
   def xml_builder
-    if ENV['DEVELOPER_MODE_ENABLED'] != 'true'
-      render(file: Rails.root.join('public/404'), layout: false, status: :not_found)
-      return
-    end
     @placements = CanvasExtensions::PLACEMENTS
   end
 
@@ -66,10 +62,6 @@ class ToolProfileController < ApplicationController
   end
 
   def xml_config
-    if ENV['DEVELOPER_MODE_ENABLED'] != 'true'
-      render(file: Rails.root.join('public/404'), layout: false, status: :not_found)
-      return
-    end
     title = t("apps.#{params[:app]}.title", default: "#{params[:app].capitalize} #{t('apps.default.title')}")
     description = t("apps.#{params[:app]}.description", default: "#{t('apps.default.title')} provider powered by BBB LTI Broker.")
     tc = IMS::LTI::Services::ToolConfig.new(title: title, launch_url: blti_launch_url(app: params[:app])) # "#{location}/#{year}/#{id}"

--- a/spec/controllers/tool_profile_controller_spec.rb
+++ b/spec/controllers/tool_profile_controller_spec.rb
@@ -29,19 +29,5 @@ RSpec.describe(ToolProfileController, type: :controller) do
       doc = Nokogiri::XML(response.body)
       expect(doc.xpath('//blti:title').text.empty?).to(be(false))
     end
-
-    it 'gives a 404 page when developer mode disabled' do
-      ENV['DEVELOPER_MODE_ENABLED'] = 'false'
-      get :xml_config, params: { app: 'default' }
-      expect(response).to(have_http_status(404))
-    end
-  end
-
-  describe 'GET :app/xml_builder' do
-    it 'gives a 404 page when developer mode disabled' do
-      ENV['DEVELOPER_MODE_ENABLED'] = 'false'
-      get :xml_config, params: { app: 'default' }
-      expect(response).to(have_http_status(404))
-    end
   end
 end


### PR DESCRIPTION
Now allows both the xml_config and xml_builder to be accessed when developer_mode is false.