### PR TITLE
LTI 70: Make sure the UI for registration only works when DEV mode is…

### DIFF
--- a/app/controllers/registration_controller.rb
+++ b/app/controllers/registration_controller.rb
@@ -26,6 +26,10 @@ class RegistrationController < ApplicationController
   include TemporaryStore
 
   def list
+    if ENV['DEVELOPER_MODE_ENABLED'] != 'true'
+      render(file: Rails.root.join('public/404'), layout: false, status: :not_found)
+      return
+    end
     @registrations = RailsLti2Provider::Tool.where(lti_version: '1.3.0').pluck(:tool_settings)
     @registrations.map! do |reg|
       JSON.parse(reg)


### PR DESCRIPTION
… enabled

When developer mode is turned off, the user cannot see all the registrations using the endpoint: https://apps.example.com/lti/registration/list

Linked Jira Ticket: https://blindsidenetworks.atlassian.net/secure/RapidBoard.jspa?rapidView=13&projectKey=LTI&modal=detail&selectedIssue=LTI-70