### PR TITLE
LTI-4: Default app should be active only when developer mode is enabled

### DIFF
--- a/app/controllers/tool_profile_controller.rb
+++ b/app/controllers/tool_profile_controller.rb
@@ -41,6 +41,10 @@ class ToolProfileController < ApplicationController
 
   # show xml builder for customization in tool consumer url
   def xml_builder
+    if ENV['DEVELOPER_MODE_ENABLED'] != 'true' && params[:app] == 'default'
+      render(file: Rails.root.join('public/404'), layout: false, status: :not_found)
+      return
+    end
     @placements = CanvasExtensions::PLACEMENTS
   end
 
@@ -78,6 +82,10 @@ class ToolProfileController < ApplicationController
   end
 
   def xml_config
+    if ENV['DEVELOPER_MODE_ENABLED'] != 'true' && params[:app] == 'default'
+      render(file: Rails.root.join('public/404'), layout: false, status: :not_found)
+      return
+    end
     title = t("apps.#{params[:app]}.title", default: "#{params[:app].capitalize} #{t('apps.default.title')}")
     description = t("apps.#{params[:app]}.description", default: "#{t('apps.default.title')} provider powered by BBB LTI Broker.")
     tc = IMS::LTI::Services::ToolConfig.new(title: title, launch_url: blti_launch_url(app: params[:app])) # "#{location}/#{year}/#{id}"


### PR DESCRIPTION
When developer_mode_enabled is turned off, the app "default" xml_builder and xml_config now gives a 404 page. 
`/lti/default/xml_builder` and `/lti/default/xml_config` returns 404.