### PR TITLE
LTI-72: App selector not working on registration/list page

### DIFF
--- a/app/assets/javascripts/registration/new.js
+++ b/app/assets/javascripts/registration/new.js
@@ -1,0 +1,20 @@
+function updateAppURL(random_key, json_config, open_id_launch, deep_link_request_launch, open_id_login){
+    let app = document.getElementById('lti_app_name').value;
+    let jsonConfig = document.getElementById('jsonconfigurl');
+    let jsonConfigLink = document.getElementById('jsonconfiglink');
+    let openIDLaunch = document.getElementById('toolurl');
+    let deepLinkRequestLaunch = document.getElementById('deeplinkurl');
+    let initLogin = document.getElementById('initloginurl');
+    let redirect = document.getElementById('redirurl');
+
+    jsonConfig.value = changeApp(json_config, random_key, app);
+    jsonConfigLink.href = jsonConfig.value;
+    openIDLaunch.value = changeApp(open_id_launch, random_key, app);
+    deepLinkRequestLaunch.value = changeApp(deep_link_request_launch, random_key, app);
+    initLogin.value = changeApp(open_id_login, random_key, app);
+    redirect.value = openIDLaunch.value + '\n' + deepLinkRequestLaunch.value
+}
+
+function changeApp(url, originalApp, newApp) {
+    return url.replace(originalApp, newApp);
+}

--- a/app/controllers/registration_controller.rb
+++ b/app/controllers/registration_controller.rb
@@ -44,6 +44,7 @@ class RegistrationController < ApplicationController
             else
               ENV['DEFAULT_LTI_TOOL']
             end
+    puts @app
     @apps = lti_apps
     set_temp_keys
     set_starter_info

--- a/app/controllers/registration_controller.rb
+++ b/app/controllers/registration_controller.rb
@@ -39,7 +39,11 @@ class RegistrationController < ApplicationController
   # only available if developer mode is on
   # production - use rails task
   def new
-    @app = ENV['DEFAULT_LTI_TOOL'] || 'default'
+    @app =  if ENV['DEVELOPER_MODE_ENABLED'] != 'true'
+              ENV['DEFAULT_LTI_TOOL'] || 'default'
+            else
+              ENV['DEFAULT_LTI_TOOL']
+            end
     @apps = lti_apps
     set_temp_keys
     set_starter_info

--- a/app/controllers/registration_controller.rb
+++ b/app/controllers/registration_controller.rb
@@ -39,11 +39,8 @@ class RegistrationController < ApplicationController
   # only available if developer mode is on
   # production - use rails task
   def new
-    @app =  if ENV['DEVELOPER_MODE_ENABLED'] != 'true'
-              ENV['DEFAULT_LTI_TOOL'] || 'default'
-            else
-              ENV['DEFAULT_LTI_TOOL']
-            end
+    @app = ENV['DEFAULT_LTI_TOOL']
+    @app ||= 'default' if ENV['DEVELOPER_MODE_ENABLED'] == 'true'
     @apps = lti_apps
     set_temp_keys
     set_starter_info

--- a/app/controllers/registration_controller.rb
+++ b/app/controllers/registration_controller.rb
@@ -44,7 +44,6 @@ class RegistrationController < ApplicationController
             else
               ENV['DEFAULT_LTI_TOOL']
             end
-    puts @app
     @apps = lti_apps
     set_temp_keys
     set_starter_info

--- a/app/views/registration/_starter_info.html.erb
+++ b/app/views/registration/_starter_info.html.erb
@@ -17,55 +17,56 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>. %>
 <%= content_tag :div do %>
     <%= button_tag t('registration.startmeoff'), :data => {:toggle => "collapse", :target => "#collapseStarterInfo"}, :type => "button", :class => "btn btn-primary" %>
     <%= content_tag :div, class: "collapse", id: "collapseStarterInfo" do %>
-        <% if @apps.length > 1 %>
+        <% if apps.length > 1 %>
+            <% random_key = Digest::SHA1.hexdigest([Time.now, rand].join)%>
             <%= content_tag :div, class: "form-group row" do %>
                 <%= label_tag(:app, t('registration.app') + ':', class: "col-sm-2 col-form-label") %>
                 <%= content_tag :div, class: "col-sm-10 col" do %>
-                    <%= select_tag 'lti_app_name', options_for_select(@apps, @apps[0]) %>
+                    <%= select_tag 'lti_app_name', options_for_select(apps, apps[0]), onchange: "updateAppURL('#{random_key}','#{json_config_url(:app => random_key, :temp_key_token => temp_key_token)}','#{openid_launch_url(:app => random_key)}','#{deep_link_request_launch_url(:app => random_key)}','#{openid_login_url(:app => random_key)}')" %>
                 <% end %>
             <% end %>
         <% end %>
         <%= content_tag :div, class: "form-group row" do %>
             <%= label_tag(:jsonconfigurl, t('registration.jsonconfigurl') + ':', class: "col-sm-2 col-form-label") %>
             <%= content_tag :div, class: "col-sm-10 col" do %>
-                <%= text_field_tag(:jsonconfigurl, json_config_url(:app => @app, :temp_key_token => @temp_key_token), :readonly => true, :class => "click-to-copy", size: 90) %>
-                <%= link_to(t('registration.showme'), json_config_url(:app => @app, :temp_key_token => @temp_key_token), :target => '_blank') %>
+                <%= text_field_tag(:jsonconfigurl, json_config_url(:app => app, :temp_key_token => temp_key_token), :readonly => true, :class => "click-to-copy", size: 90) %>
+                <%= link_to(t('registration.showme'), json_config_url(:app => app, :temp_key_token => temp_key_token), id: :jsonconfiglink, :target => '_blank') %>
             <% end %>
         <% end %>
         <%= content_tag :div, class: "form-group row" do %>
             <%= label_tag(:toolurl, t('registration.toolurl') + ':', class: "col-sm-2 col-form-label") %>
             <%= content_tag :div, class: "col-sm-10 col" do %>
-                <%= text_field_tag(:toolurl, openid_launch_url(:app => @app), :readonly => true, :class => "click-to-copy", size: 90) %>
+                <%= text_field_tag(:toolurl, openid_launch_url(:app => app), :readonly => true, :class => "click-to-copy", size: 90) %>
             <% end %>
         <% end %>
         <%= content_tag :div, class: "form-group row" do %>
             <%= label_tag(:deeplinkurl, t('registration.deeplinkurl') + ':', class: "col-sm-2 col-form-label") %>
             <%= content_tag :div, class: "col-sm-10 col" do %>
-                <%= text_field_tag(:deeplinkurl, deep_link_request_launch_url(:app => @app), :readonly => true, :class => "click-to-copy", size: 90) %>
+                <%= text_field_tag(:deeplinkurl, deep_link_request_launch_url(:app => app), :readonly => true, :class => "click-to-copy", size: 90) %>
             <% end %>
         <% end %>
         <%= content_tag :div, class: "form-group row" do %>
             <%= label_tag(:initloginurl, t('registration.initloginurl') + ':', class: "col-sm-2 col-form-label") %>
             <%= content_tag :div, class: "col-sm-10 col" do %>
-                <%= text_field_tag(:initloginurl, openid_login_url(:app => @app), :readonly => true, :class => "click-to-copy", size: 90) %>
+                <%= text_field_tag(:initloginurl, openid_login_url(:app => app), :readonly => true, :class => "click-to-copy", size: 90) %>
             <% end %>
         <% end %>
         <%= content_tag :div, class: "form-group row" do %>
             <%= label_tag(:publickey, t('registration.publickey') + ':', class: "col-sm-2 col-form-label") %>
             <%= content_tag :div, class: "col-sm-10 col" do %>
-                <%= text_area_tag(:publickey, @public_key, :readonly => true, :class => "click-to-copy", size: "90x15") %>
+                <%= text_area_tag(:publickey, public_key, :readonly => true, :class => "click-to-copy", size: "90x15") %>
             <% end %>
         <% end %>
         <%= content_tag :div, class: "form-group row" do %>
             <%= label_tag(:jwk, t('registration.jwk') + ':', class: "col-sm-2 col-form-label") %>
             <%= content_tag :div, class: "col-sm-10 col" do %>
-                <%= text_area_tag(:jwk, @jwk, :readonly => true, :class => "click-to-copy", size: "90x15") %>
+                <%= text_area_tag(:jwk, jwk, :readonly => true, :class => "click-to-copy", size: "90x15") %>
             <% end %>
         <% end %>
         <%= content_tag :div, class: "form-group row" do %>
             <%= label_tag(:redirurl, t('registration.redirurl') + ':', class: "col-sm-2 col-form-label") %>
             <%= content_tag :div, class: "col-sm-10 col" do %>
-                <%= text_area_tag(:redirurl, @redirect_uri, :escape => false, :readonly => true, :class => "click-to-copy", size: "90x2") %>
+                <%= text_area_tag(:redirurl, redirect_uri, :escape => false, :readonly => true, :class => "click-to-copy", size: "90x2") %>
             <% end %>
         <% end %>
     <% end %>

--- a/app/views/registration/_starter_info.html.erb
+++ b/app/views/registration/_starter_info.html.erb
@@ -22,7 +22,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>. %>
             <%= content_tag :div, class: "form-group row" do %>
                 <%= label_tag(:app, t('registration.app') + ':', class: "col-sm-2 col-form-label") %>
                 <%= content_tag :div, class: "col-sm-10 col" do %>
-                    <%= select_tag 'lti_app_name', options_for_select(apps, apps[0]), onchange: "updateAppURL('#{random_key}','#{json_config_url(:app => random_key, :temp_key_token => temp_key_token)}','#{openid_launch_url(:app => random_key)}','#{deep_link_request_launch_url(:app => random_key)}','#{openid_login_url(:app => random_key)}')" %>
+                    <%= select_tag 'lti_app_name', options_for_select(apps, app), onchange: "updateAppURL('#{random_key}','#{json_config_url(:app => random_key, :temp_key_token => temp_key_token)}','#{openid_launch_url(:app => random_key)}','#{deep_link_request_launch_url(:app => random_key)}','#{openid_login_url(:app => random_key)}')" %>
                 <% end %>
             <% end %>
         <% end %>

--- a/app/views/registration/new.html.erb
+++ b/app/views/registration/new.html.erb
@@ -17,7 +17,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>. %>
 <div>
     <%= link_to t('registration.goback'), registration_list_url %>
     <h3><%= t('registration.newreg') %></h3>
-    <%= render 'starter_info' %>
+    <%= render 'starter_info', :app => @app, :apps => @apps, :temp_key_token => @temp_key_token, :jwk => @jwk, :redirect_uri => @redirect_uri, :public_key => @public_key %>
     <br>
     <%= form_tag(submit_registration_path) do %>
         <%= content_tag :div, class: "form-group row" do %>


### PR DESCRIPTION
Now changes the links shown in the "Start Me Off" section of registering a new tool consumer.
The links will be changed so that the app in the links is the same as the app selected in the drop down menu.

Linked Jira Ticket: https://blindsidenetworks.atlassian.net/secure/RapidBoard.jspa?rapidView=13&projectKey=LTI&modal=detail&selectedIssue=LTI-72