### PR TITLE
LTI-48: Database seetings should only use the DATABASE_URL variable

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,9 +1,5 @@
 default: &default
   encoding: unicode
-  adapter: postgresql
-  host: ''
-  username: <%= ENV['DATABASE_USERNAME'] %>
-  password: <%= ENV['DATABASE_PASSWORD'] %>
   pool: 5
   timeout: 5000
   url: <%= ENV['DATABASE_URL'] || 'postgres://localhost:5432' %>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   postgres:
     image: postgres:11-alpine
     environment:
-      POSTGRES_PASSWORD: password
+      DATABASE_URL: ${DATABASE_URL:-postgresql://postgres:password@localhost:5432/bbb_lti_broker}
     volumes:
       - ./data/postgres/:/var/lib/postgresql/data
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   postgres:
     image: postgres:11-alpine
     environment:
-      DATABASE_URL: ${DATABASE_URL:-postgresql://postgres:password@localhost:5432/bbb_lti_broker}
+      POSTGRES_PASSWORD: password
     volumes:
       - ./data/postgres/:/var/lib/postgresql/data
     ports:


### PR DESCRIPTION
Now uses database_url in both database.yml and docker-compose.yml

Linked JIRA ticket: https://blindsidenetworks.atlassian.net/secure/RapidBoard.jspa?rapidView=13&projectKey=LTI&modal=detail&selectedIssue=LTI-48