### PR TITLE
LTI-78: Unsecure icon shown in production for LTI 1.1

### DIFF
--- a/app/controllers/concerns/apps_validator.rb
+++ b/app/controllers/concerns/apps_validator.rb
@@ -80,7 +80,7 @@ module AppsValidator
 
     begin
       app = lti_app(app_name)
-      uri = URI.parse(app['redirect_uri'])
+      uri = URI.parse(app['redirect_uri'].sub('https', 'http'))
       site = "#{uri.scheme}://#{uri.host}#{uri.port != 80 ? ':' + uri.port.to_s : ''}/"
       path = uri.path.split('/')
       path_base = (path[0].chomp(' ') == '' ? path[1] : path[0]).gsub('/', '') + '/'

--- a/app/controllers/tool_profile_controller.rb
+++ b/app/controllers/tool_profile_controller.rb
@@ -88,7 +88,7 @@ class ToolProfileController < ApplicationController
     end
     title = t("apps.#{params[:app]}.title", default: "#{params[:app].capitalize} #{t('apps.default.title')}")
     description = t("apps.#{params[:app]}.description", default: "#{t('apps.default.title')} provider powered by BBB LTI Broker.")
-    tc = IMS::LTI::Services::ToolConfig.new(title: title, launch_url: blti_launch_url(app: params[:app])) # "#{location}/#{year}/#{id}"
+    tc = IMS::LTI::Services::ToolConfig.new(title: title, launch_url: blti_launch_url(app: params[:app]).sub('https', 'http')) # "#{location}/#{year}/#{id}"
     tc.secure_launch_url = secure_url(tc.launch_url)
     tc.icon = lti_icon(params[:app])
     tc.secure_icon = secure_url(tc.icon)

--- a/app/controllers/tool_profile_controller.rb
+++ b/app/controllers/tool_profile_controller.rb
@@ -106,6 +106,9 @@ class ToolProfileController < ApplicationController
       params[:custom_params]&.each { |_, v| tc.set_custom_param(v[:name].to_sym, v[:value]) }
       params[:placements]&.each { |k, _| create_placement(tc, k.to_sym) }
     end
+
+    tc.icon = nil if ENV['DEVELOPER_MODE_ENABLED'] != 'true'
+
     render(xml: tc.to_xml(indent: 2))
   end
 

--- a/app/controllers/tool_profile_controller.rb
+++ b/app/controllers/tool_profile_controller.rb
@@ -107,8 +107,6 @@ class ToolProfileController < ApplicationController
       params[:placements]&.each { |k, _| create_placement(tc, k.to_sym) }
     end
 
-    tc.icon = nil if ENV['DEVELOPER_MODE_ENABLED'] != 'true'
-
     render(xml: tc.to_xml(indent: 2))
   end
 


### PR DESCRIPTION
Now changes the unsecure icon in cartridge from https to http, and removes the port :443

Before:
![image](https://user-images.githubusercontent.com/21375588/91351500-68690a80-e7b6-11ea-9941-f5ef45f3609f.png)

After:
![image](https://user-images.githubusercontent.com/21375588/91485789-6451f100-e879-11ea-80a8-657ac3a5f91f.png)


