### PR TITLE
LTI-76: Add TLS support for redis

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,8 @@ gem 'rails_lti2_provider', git: 'https://github.com/blindsidenetworks/rails_lti2
 
 gem 'activerecord-session_store'
 
+gem 'redis', '~> 4.0'
+
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,6 +231,7 @@ GEM
       execjs
       railties (>= 3.2)
       tilt
+    redis (4.2.2)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -353,6 +354,7 @@ DEPENDENCIES
   rails (>= 6.0.3.3)
   rails_lti2_provider!
   react-rails
+  redis (~> 4.0)
   rspec
   rspec-rails
   rubocop (~> 0.79.0)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,7 +34,17 @@ Rails.application.configure do
 
   # Enable/disable caching. By default caching is disabled.
   config.action_controller.perform_caching = true
-  config.cache_store = :file_store, Rails.root.join('tmp/cache_store')
+  config.cache_store = if ENV['REDIS_URL'].present?
+                         # Set up Redis cache store
+                         [:redis_cache_store, { url: ENV['REDIS_URL'],
+
+                                                connect_timeout: 30, # Defaults to 20 seconds
+                                                read_timeout: 0.2, # Defaults to 1 second
+                                                write_timeout: 0.2, # Defaults to 1 second
+                                                reconnect_attempts: 1, },] # Defaults to 0,]
+                       else
+                         config.cache_store = :file_store, Rails.root.join('tmp/cache_store')
+                       end
   if Rails.root.join('tmp/caching-dev.txt').exist?
     config.public_file_server.headers = {
       'Cache-Control' => 'public, max-age=172800',

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -102,6 +102,22 @@ Rails.application.configure do
     config.logger = ActiveSupport::TaggedLogging.new(logger)
   end
 
+  config.cache_store = if ENV['REDIS_URL'].present?
+                         # Set up Redis cache store
+                         [:redis_cache_store, { url: ENV['REDIS_URL'],
+
+                                                connect_timeout: 30, # Defaults to 20 seconds
+                                                read_timeout: 0.2, # Defaults to 1 second
+                                                write_timeout: 0.2, # Defaults to 1 second
+                                                reconnect_attempts: 1, # Defaults to 0
+
+                                                error_handler: lambda { |method:, returning:, exception:|
+                                                                 config.logger.warn("Support: Redis cache action #{method} failed and returned '#{returning}': #{exception}")
+                                                               }, },]
+                       else
+                         config.cache_store = :file_store, Rails.root.join('tmp/cache_store')
+                       end
+
   config.hosts = ENV['WHITELIST_HOST'].presence || nil
 
   config.react.variant = :production

--- a/dotenv
+++ b/dotenv
@@ -27,7 +27,7 @@ RAILS_SERVE_STATIC_FILES=true
 # HOST_URL=broker.example.com
 
 ## Enable redis for actioncable
-# REDIS_URL=
+# REDIS_URL=redis://myuser:mypass@localhost
 
 ## Use DATABASE_URL when using a postgres outside the pre-packaged with docker-compose
 ## DATABASE_URL=postgres://myuser:mypass@localhost

--- a/dotenv
+++ b/dotenv
@@ -26,6 +26,9 @@ RAILS_SERVE_STATIC_FILES=true
 
 # HOST_URL=broker.example.com
 
+## Enable redis for actioncable
+# REDIS_URL=
+
 ## Use DATABASE_URL when using a postgres outside the pre-packaged with docker-compose
 ## DATABASE_URL=postgres://myuser:mypass@localhost
 


### PR DESCRIPTION
Now uses redis with tls for action cable

NOTE: Needs the environment variable below
`REDIS_URL`