### PR TITLE
(CLEAN UP) LTI 76: Add TLS Support for redis

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ gem 'rails_lti2_provider', git: 'https://github.com/blindsidenetworks/rails_lti2
 
 gem 'activerecord-session_store'
 
-gem 'redis', '~> 4.0'
+gem 'redis', '~> 4.2'
 
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -354,7 +354,7 @@ DEPENDENCIES
   rails (>= 6.0.3.3)
   rails_lti2_provider!
   react-rails
-  redis (~> 4.0)
+  redis (~> 4.2)
   rspec
   rspec-rails
   rubocop (~> 0.79.0)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -43,7 +43,7 @@ Rails.application.configure do
                                                 write_timeout: 0.2, # Defaults to 1 second
                                                 reconnect_attempts: 1, },] # Defaults to 0,]
                        else
-                         config.cache_store = :file_store, Rails.root.join('tmp/cache_store')
+                         [:file_store, Rails.root.join('tmp/cache_store')]
                        end
   if Rails.root.join('tmp/caching-dev.txt').exist?
     config.public_file_server.headers = {

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -115,7 +115,7 @@ Rails.application.configure do
                                                                  config.logger.warn("Support: Redis cache action #{method} failed and returned '#{returning}': #{exception}")
                                                                }, },]
                        else
-                         config.cache_store = :file_store, Rails.root.join('tmp/cache_store')
+                         [:file_store, Rails.root.join('tmp/cache_store')]
                        end
 
   config.hosts = ENV['WHITELIST_HOST'].presence || nil


### PR DESCRIPTION
Standardizes redis version for broker so that it is the same with bbb-app-rooms.
Fixes code redundancy as well.