### PR TITLE
LTI-118: The UI for registering LTI 1.3 is completely off

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -68,7 +68,7 @@ html, body {
     border-top: 1px solid $primary-transparency;
     font-size: 12px;
     width: 100%;
-    position: fixed;
+    position: relative;
 }
 
 .background {
@@ -84,5 +84,5 @@ html, body {
 .wrapper {
     width: 100%;
     position: relative;
-    height: calc(100% - #{$header-height} - #{$footer-height});
+    min-height: calc(100% - #{$header-height} - #{$footer-height});
 }

--- a/app/assets/stylesheets/registration.css
+++ b/app/assets/stylesheets/registration.css
@@ -71,7 +71,3 @@ textarea[readonly] {
 .form-required-txt {
     color: #d21d1d;
 }
-
-.registration-form {
-    padding-bottom: 7rem;
-}


### PR DESCRIPTION
No longer has the overlapping footer when the collapse element uncollapses:

![image](https://user-images.githubusercontent.com/21375588/97910870-5e183f00-1d18-11eb-814b-376e2f6b1725.png)
![image](https://user-images.githubusercontent.com/21375588/97910934-7d16d100-1d18-11eb-83fc-2d864105ffd4.png)

Linked Jira Ticket: https://blindsidenetworks.atlassian.net/secure/RapidBoard.jspa?rapidView=13&projectKey=LTI&modal=detail&selectedIssue=LTI-118
