### PR TITLE
LTI-XX: Dependabot updates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -244,7 +244,7 @@ GEM
     puma (5.6.4)
       nio4r (~> 2.0)
     racc (1.6.1)
-    rack (2.2.4)
+    rack (2.2.6.2)
     rack-test (2.0.2)
       rack (>= 1.3)
     rails (6.0.6)


### PR DESCRIPTION
putting them in one PR to fix the branch naming issues, which wasn't allowing the docker image to be built.