### PR TITLE
LTI-252: Add show task for key

### DIFF
--- a/app/controllers/registration_controller.rb
+++ b/app/controllers/registration_controller.rb
@@ -41,8 +41,7 @@ class RegistrationController < ApplicationController
   # only available if developer mode is on
   # production - use rails task
   def new
-    @app = ENV['DEFAULT_LTI_TOOL']
-    @app ||= 'default' if ENV['DEVELOPER_MODE_ENABLED'] == 'true'
+    @app = Rails.configuration.default_tool
     @apps = lti_apps
     set_temp_keys
     set_starter_info

--- a/app/views/application/index.html.erb
+++ b/app/views/application/index.html.erb
@@ -34,7 +34,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>. %>
 
     <h2>LTI Launch</h2>
 
-    <p>The LTI Launch endpoint is <%= link_to(blti_launch_url(app: ENV['DEFAULT_LTI_TOOL']), blti_launch_url(app: ENV['DEFAULT_LTI_TOOL'])) %>.</p>
+    <p>The LTI Launch endpoint is <%= link_to(blti_launch_url(app: Rails.configuration.default_tool), blti_launch_url(app: Rails.configuration.default_tool)) %>.</p>
 
     <p>Note, this url is typically sent a POST request with all sorts of LTI data.  If you access it directly, it'll display an error page indicating your request did not validate.</p>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -47,6 +47,6 @@ module BbbLtiBroker
 
     config.handler_legacy_patterns = ENV['HANDLER_LEGACY_PATTERNS'] || 'param-resource_link_id,param-oauth_consumer_key'
 
-    config.default_tool = ENV['DEFAULT_LTI_TOOL'] || 'rooms'
+    config.default_tool = ENV['DEFAULT_LTI_TOOL'] || 'default'
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -46,5 +46,7 @@ module BbbLtiBroker
     config.relative_url_root = "/#{ENV['RELATIVE_URL_ROOT']}"
 
     config.handler_legacy_patterns = ENV['HANDLER_LEGACY_PATTERNS'] || 'param-resource_link_id,param-oauth_consumer_key'
+
+    config.default_tool = ENV['DEFAULT_LTI_TOOL'] || 'rooms'
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,8 +22,8 @@ Rails.application.routes.draw do
   root 'application#index'
 
   # A monkey patch for supporting links coming from legacy LTI tools that hardcoded the launch under tool.
-  get '(:tenant)/tool(.xml)', to: 'tool_profile#xml_config_legacy', app: ENV['DEFAULT_LTI_TOOL'] || 'default'
-  post '(:tenant)/tool', to: 'message#basic_lti_launch_request_legacy', as: 'blti_launch_legacy', app: ENV['DEFAULT_LTI_TOOL'] || 'default'
+  get '(:tenant)/tool(.xml)', to: 'tool_profile#xml_config_legacy', app: Rails.configuration.default_tool
+  post '(:tenant)/tool', to: 'message#basic_lti_launch_request_legacy', as: 'blti_launch_legacy', app: Rails.configuration.default_tool
 
   # rooms calls this api to validate launch from broker
   namespace :api do
@@ -57,7 +57,7 @@ Rails.application.routes.draw do
   post ':app/auth/login', to: 'auth#login', as: 'openid_login'
   post ':app/messages/oblti', to: 'message#openid_launch_request', as: 'openid_launch'
   # requests from tool consumer go through this path
-  get ':app/messages/blti', to: 'tool_profile#xml_config', app: ENV['DEFAULT_LTI_TOOL'] || 'default'
+  get ':app/messages/blti', to: 'tool_profile#xml_config', app: Rails.configuration.default_tool
   post ':app/messages/blti', to: 'message#basic_lti_launch_request', as: 'blti_launch'
 
   # requests from xml_config go through these paths
@@ -72,8 +72,8 @@ Rails.application.routes.draw do
   match ':app/json_config/:temp_key_token', to: 'tool_profile#json_config', via: [:get, :post], as: 'json_config' # , :defaults => {:format => 'json'}
 
   # xml config and builder for lti 1.0/1.1
-  get ':app/xml_config', to: 'tool_profile#xml_config', app: ENV['DEFAULT_LTI_TOOL'] || 'default', as: :xml_config
-  get ':app/xml_builder', to: 'tool_profile#xml_builder', app: ENV['DEFAULT_LTI_TOOL'] || 'default', as: :xml_builder
+  get ':app/xml_config', to: 'tool_profile#xml_config', app: Rails.configuration.default_tool, as: :xml_config
+  get ':app/xml_builder', to: 'tool_profile#xml_builder', app: Rails.configuration.default_tool, as: :xml_builder
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
   get '/errors/:code', to: 'errors#index', as: :errors

--- a/lib/tasks/db_keys.rake
+++ b/lib/tasks/db_keys.rake
@@ -125,7 +125,15 @@ namespace :db do
       tool = RailsLti2Provider::Tool.find_by(uuid: args[:key], tenant: tenant)
       for_tenant = tenant.uid.empty? ? '' : tenant.uid
       abort("Key '#{args[:key]}' does not exist for tenant '#{for_tenant}'.") if tool.nil?
-      puts("'#{tool.uuid}'='#{tool.shared_secret}' for tenant '#{for_tenant}'.")
+
+      tool_name = Rails.configuration.default_tool
+      url = Rails.configuration.url_host
+      url_root = Rails.configuration.relative_url_root[1..] # remove leading '/'
+      url = "https://#{url}" unless url.first(4) == 'http'
+      url += '/' unless url.last(1) == '/'
+      url += "#{url_root}/#{tool_name}/messages/blti"
+
+      puts("Key:\t#{tool.uuid}\nSecret:\t#{tool.shared_secret}\nURL:\t#{url}")
 
     rescue StandardError => e
       puts(e.backtrace)


### PR DESCRIPTION
Use rake db:keys:show[key,tenant] to get the key, secret, and URL.
Note that the URL will only be correct if the tool used is the same as the DEFAULT_LTI_TOOL environment variable. For example, if the DEFAULT_LTI_TOOL= rooms, then the URL will shows rooms even if the app being used is lectures. 