### PR TITLE
LTI-279: Add ability to specify params used for app handler

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -27,7 +27,7 @@ Rails.application.configure do
   config.cache_classes = false
 
   # Whitelist IPs
-  config.web_console.whitelisted_ips = '10.0.0.0/16'
+  config.web_console.allowed_ips = '10.0.0.0/16'
 
   # Do not eager load code on boot.
   config.eager_load = false


### PR DESCRIPTION
**Description**
A custom 'handler_params' setting can be added to tenants in the broker via the new rake task. These params can be used in the rooms app to form the room handler. By default, if no params are specified in the broker, the app will use the 'resource_link_id' parameter to form the handler. 

**How to Specify Params**
```
# The rake task first takes a tenant's uid. the second parameter must be 'handler_params', and the third parameter is a string with as many params as you like, separated by an escaped comma, as shown below:
rake db:tenants:settings:upsert[tenant_id, handler_params,"context_id\,resource_link_id"] 

# You can delete all handler parameters by using the following task:
rake db:tenants:settings:delete[tenant_uid,handler_params]
```
**Things to Note**
- Ensure that you are using the correct version of the Rooms app that supports using handler params from the broker. 
- By changing the params used for the handler will change, you will lose previous instances of Rooms. They won't be deleted from the database, but rather if you launch a Room that had been previously set up, it will be launched as a new room. The major consequence of this is that any recordings in the previous room will be lost.

**How to test**
Specify the params you would like to use for your tenant's rooms, and then create various rooms within one course and across a couple of courses, ensuring that the rooms are unique (this can be done by simply changing the room name or description). 