### PR TITLE
LTI-309: Store RSA keys in the database instead of file system [feat]

### DIFF
--- a/app/controllers/concerns/deep_link_service.rb
+++ b/app/controllers/concerns/deep_link_service.rb
@@ -56,7 +56,8 @@ module DeepLinkService
       message[key] = '' if value.nil?
     end
 
-    priv = File.read(registration['tool_private_key'])
+    key_pair_id = JSON.parse(registration['tool_settings'])['rsa_key_pair_id']
+    priv = RsaKeyPair.find(key_pair_id).private_key
     priv_key = OpenSSL::PKey::RSA.new(priv)
 
     JWT.encode(message, priv_key, 'RS256', kid: jwt_header['kid'])

--- a/app/controllers/concerns/open_id_authenticator.rb
+++ b/app/controllers/concerns/open_id_authenticator.rb
@@ -69,7 +69,13 @@ module OpenIdAuthenticator
   end
 
   def validate_registration(jwt_body)
-    registration = RailsLti2Provider::Tool.find_by_issuer(jwt_body['iss'])
+    issuer = jwt_body['iss']
+
+    options = {}
+    options['client_id'] = jwt_body['aud']
+
+    registration = RailsLti2Provider::Tool.find_by_issuer(issuer, options)
+
     raise CustomError, :not_registered if registration.nil?
     raise CustomError, :disabled if registration.disabled?
 

--- a/app/controllers/concerns/platform_service_connector.rb
+++ b/app/controllers/concerns/platform_service_connector.rb
@@ -32,7 +32,8 @@ module PlatformServiceConnector
       jti: "lti-service-token#{SecureRandom.hex}",
     }
 
-    priv = File.read(registration['tool_private_key'])
+    key_pair_id = JSON.parse(registration['tool_settings'])['rsa_key_pair_id']
+    priv = RsaKeyPair.find(key_pair_id).private_key
     priv_key = OpenSSL::PKey::RSA.new(priv)
 
     jwt = JWT.encode(jwt_claim, priv_key, 'RS256')

--- a/app/models/rsa_key_pair.rb
+++ b/app/models/rsa_key_pair.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# BigBlueButton open source conferencing system - http://www.bigbluebutton.org/.
+
+# Copyright (c) 2018 BigBlueButton Inc. and by respective authors (see below).
+
+# This program is free software; you can redistribute it and/or modify it under the
+# terms of the GNU Lesser General Public License as published by the Free Software
+# Foundation; either version 3.0 of the License, or (at your option) any later
+# version.
+
+# BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+
+# You should have received a copy of the GNU Lesser General Public License along
+# with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+
+class RsaKeyPair < ApplicationRecord
+  def tool
+    RailsLti2Provider::Tool.find_by_issuer(tool_id)
+  end
+end

--- a/db/migrate/20240313175732_create_rsa_key_pairs.rb
+++ b/db/migrate/20240313175732_create_rsa_key_pairs.rb
@@ -1,0 +1,11 @@
+class CreateRsaKeyPairs < ActiveRecord::Migration[6.1]
+  def change
+    create_table :rsa_key_pairs do |t|
+      t.text :private_key
+      t.text :public_key
+      t.string :tool_id
+
+      t.timestamps null:false, precision: 6
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -102,6 +102,14 @@ ActiveRecord::Schema.define(version: 2024_03_19_175531) do
     t.index ["tenant_id"], name: "index_tenant_id"
   end
 
+  create_table "rsa_key_pairs", force: :cascade do |t|
+    t.text "private_key"
+    t.text "public_key"
+    t.string "tool_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "sessions", force: :cascade do |t|
     t.string "session_id", null: false
     t.text "data"

--- a/lib/tasks/tool.rake
+++ b/lib/tasks/tool.rake
@@ -19,6 +19,7 @@ namespace :tool do
     end
     abort('The Issuer must be valid.') if issuer.blank?
 
+    puts("tenant is: #{args[:tenant_uid]}")
     # Validate the tenant as it is a point of failure and if not valid, there is no point on continuing.
     tenant = RailsLti2Provider::Tenant.find_by(uid: args[:tenant_uid]) if args[:tenant_uid].present?
     tenant = RailsLti2Provider::Tenant.first if tenant.nil?
@@ -60,23 +61,11 @@ namespace :tool do
     private_key = OpenSSL::PKey::RSA.generate(4096)
     public_key = private_key.public_key
 
-    key_dir = Digest::MD5.hexdigest(SecureRandom.uuid)
-    Dir.mkdir('.ssh/') unless Dir.exist?('.ssh/')
-    Dir.mkdir(".ssh/#{key_dir}") unless Dir.exist?(".ssh/#{key_dir}")
-
-    File.open(Rails.root.join(".ssh/#{key_dir}/priv_key"), 'w') do |f|
-      f.puts(private_key.to_s)
-    end
-
-    File.open(Rails.root.join(".ssh/#{key_dir}/pub_key"), 'w') do |f|
-      f.puts(public_key.to_s)
-    end
-
-    # Only required for the output for cases when the private key is required as a token.
-    jwk = JWT::JWK.new(private_key).export
-    jwk['alg'] = 'RS256' unless jwk.key?('alg')
-    jwk['use'] = 'sig' unless jwk.key?('use')
-    jwk = jwk.to_json
+    rsa_key_pair = RsaKeyPair.create(
+      private_key: private_key.to_s,
+      public_key: public_key.to_s,
+      tool_id: issuer
+    )
 
     reg = {
       issuer: issuer,
@@ -84,7 +73,7 @@ namespace :tool do
       key_set_url: key_set_url,
       auth_token_url: auth_token_url,
       auth_login_url: auth_login_url,
-      tool_private_key: Rails.root.join(".ssh/#{key_dir}/priv_key"),
+      rsa_key_pair_id: rsa_key_pair.id,
     }
 
     tool = RailsLti2Provider::Tool.create(
@@ -111,7 +100,7 @@ namespace :tool do
   namespace :show do
     desc 'Show a tool by [key,value]'
     task :by, [:key, :value] => :environment do |_t, args|
-      $stdout.puts('tool:destroy:by[key,value]')
+      $stdout.puts('tool:show:by[key,value]')
 
       # Key.
       key = args[:key]
@@ -132,18 +121,18 @@ namespace :tool do
       tool = RailsLti2Provider::Tool.find_by(lti_version: '1.3.0', key.to_sym => value)
       abort("The tool with #{key} = #{value} does not exist") if tool.blank?
 
-      key_dir = Pathname.new(JSON.parse(tool.tool_settings)['tool_private_key']).parent.to_s
-      private_key = File.read("#{key_dir}/priv_key")
-      public_key = File.read("#{key_dir}/pub_key")
+      if (key_pair_id = JSON.parse(tool.tool_settings)['rsa_key_pair_id'])
+        keys = RsaKeyPair.find(key_pair_id)
+      end
 
       output = "{'id': '#{tool.id}', 'uuid': '#{tool.uuid}', 'shared_secret': '#{tool.shared_secret}'}"
       output += " for tenant '#{tool.tenant.uid}'" unless tool.tenant.uid.empty?
       output += " is #{tool.status}"
       puts(output)
       $stdout.puts("\n")
-      $stdout.puts("Private Key:\n#{private_key}")
+      $stdout.puts("Private Key:\n#{keys.private_key}")
       $stdout.puts("\n")
-      $stdout.puts("Public Key:\n#{public_key}")
+      $stdout.puts("Public Key:\n#{keys.public_key}")
       $stdout.puts("\n")
     rescue StandardError => e
       puts(e.backtrace)
@@ -172,18 +161,18 @@ namespace :tool do
       tool = RailsLti2Provider::Tool.find_by(lti_version: '1.3.0', id: id)
       abort("The tool with ID #{id} does not exist") if tool.blank?
 
-      key_dir = Pathname.new(JSON.parse(tool.tool_settings)['tool_private_key']).parent.to_s
-      private_key = File.read("#{key_dir}/priv_key")
-      public_key = File.read("#{key_dir}/pub_key")
+      if (key_pair_id = JSON.parse(tool.tool_settings)['rsa_key_pair_id'])
+        keys = RsaKeyPair.find(key_pair_id)
+      end
 
       output = "{'id': '#{tool.id}', 'uuid': '#{tool.uuid}', 'shared_secret': '#{tool.shared_secret}'}"
       output += " for tenant '#{tool.tenant.uid}'" unless tool.tenant.uid.empty?
       output += " is #{tool.status}"
       puts(output)
       $stdout.puts("\n")
-      $stdout.puts("Private Key:\n#{private_key}")
+      $stdout.puts("Private Key:\n#{keys.private_key}")
       $stdout.puts("\n")
-      $stdout.puts("Public Key:\n#{public_key}")
+      $stdout.puts("Public Key:\n#{keys.public_key}")
       $stdout.puts("\n")
     rescue StandardError => e
       puts(e.backtrace)
@@ -293,34 +282,16 @@ namespace :tool do
 
     private_key = OpenSSL::PKey::RSA.generate(4096)
     public_key = private_key.public_key
-    jwk = JWT::JWK.new(private_key).export
-    jwk['alg'] = 'RS256' unless jwk.key?('alg')
-    jwk['use'] = 'sig' unless jwk.key?('use')
-    jwk = jwk.to_json
 
-    key_dir = Digest::MD5.hexdigest(SecureRandom.uuid)
-    Dir.mkdir('.ssh/') unless Dir.exist?('.ssh/')
-    Dir.mkdir(".ssh/#{key_dir}") unless Dir.exist?(".ssh/#{key_dir}")
+    key_pair_id = JSON.parse(tool.tool_settings)['rsa_key_pair_id']
+    old_keys_obj = RsaKeyPair.find(key_pair_id)
 
-    # File.open(File.join(Rails.root, '.ssh', key_dir, 'priv_key'), 'w') do |f|
-    #   f.puts(private_key.to_s)
-    # end
-    File.open(Rails.root.join(".ssh/#{key_dir}/priv_key"), 'w') do |f|
-      f.puts(private_key.to_s)
-    end
-
-    # File.open(File.join(Rails.root, '.ssh', key_dir, 'pub_key'), 'w') do |f|
-    #   f.puts(public_key.to_s)
-    # end
-    File.open(Rails.root.join(".ssh/#{key_dir}/pub_key"), 'w') do |f|
-      f.puts(public_key.to_s)
-    end
+    old_keys_obj.update({ private_key: private_key, public_key: public_key })
 
     tool_settings = JSON.parse(tool.tool_settings)
     tool_settings['tool_private_key'] = Rails.root.join(".ssh/#{key_dir}/priv_key") # "#{Rails.root}/.ssh/#{key_dir}/priv_key"
     tool.update(tool_settings: tool_settings.to_json, shared_secret: client_id)
 
-    puts(jwk) if args[:type] == 'jwk'
     puts(public_key) if args[:type] == 'key'
   end
 

--- a/lib/tasks/tool.rake
+++ b/lib/tasks/tool.rake
@@ -19,7 +19,6 @@ namespace :tool do
     end
     abort('The Issuer must be valid.') if issuer.blank?
 
-    puts("tenant is: #{args[:tenant_uid]}")
     # Validate the tenant as it is a point of failure and if not valid, there is no point on continuing.
     tenant = RailsLti2Provider::Tenant.find_by(uid: args[:tenant_uid]) if args[:tenant_uid].present?
     tenant = RailsLti2Provider::Tenant.first if tenant.nil?

--- a/lib/tasks/tool.rake
+++ b/lib/tasks/tool.rake
@@ -89,8 +89,6 @@ namespace :tool do
     $stdout.puts("\n")
     $stdout.puts("Public Key:\n#{public_key}")
     $stdout.puts("\n")
-    $stdout.puts("JWK:\n#{jwk}")
-    $stdout.puts("\n")
   rescue StandardError => e
     puts(e.backtrace)
     exit(1)
@@ -265,10 +263,8 @@ namespace :tool do
     exit(1)
   end
 
-  desc 'Generate new key pair for existing Tool configuration [key, jwk]'
-  task :keygen, [:type] => :environment do |_t, args|
-    abort('Type must be one of [key, jwk]') unless %w[key jwk].include?(args[:type])
-
+  desc 'Generate new key pair for existing Tool configuration'
+  task keygen: :environment do |_t|
     $stdout.puts('What is the issuer for the tool?')
     issuer = $stdin.gets.strip
     $stdout.puts('What is the client ID for the tool?')
@@ -287,11 +283,7 @@ namespace :tool do
 
     old_keys_obj.update({ private_key: private_key, public_key: public_key })
 
-    tool_settings = JSON.parse(tool.tool_settings)
-    tool_settings['tool_private_key'] = Rails.root.join(".ssh/#{key_dir}/priv_key") # "#{Rails.root}/.ssh/#{key_dir}/priv_key"
-    tool.update(tool_settings: tool_settings.to_json, shared_secret: client_id)
-
-    puts(public_key) if args[:type] == 'key'
+    puts(public_key)
   end
 
   desc 'Lists the Registration Configuration URLs need to register an app [app]'


### PR DESCRIPTION
Store the RSA keys in the database instead of the file system.
Note that this is **not backwards compatible**. You will need to re-register tools that had been registered with the old system. 
