### PR TITLE
LTI-320: assign app icon to deep-link selector instead of hardcoded one

### DIFF
--- a/app/controllers/concerns/apps_validator.rb
+++ b/app/controllers/concerns/apps_validator.rb
@@ -60,6 +60,8 @@ module AppsValidator
     uri_path = uri.path.split('/')
     uri_path.delete_at(0)
     uri_path = uri_path.first(uri_path.size - 3) unless uri_path.size < 3
+    uri_path = Rails.configuration.relative_url_root.sub(%r{^/}, '').split('/') if name == 'default'
+
     "/#{uri_path.join('/')}#{path}"
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -17,4 +17,5 @@
 # with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
 module ApplicationHelper
+  include AppsValidator
 end

--- a/app/views/message/deep_link.html.erb
+++ b/app/views/message/deep_link.html.erb
@@ -24,7 +24,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>. %>
 					<div class="card tool-card clickable">
 						<div class="card-body text-center">
 							<div class="tool-logo-background">
-								<%= image_tag("bbb_logo.png", alt: "Icon", size: "35", class: "img-fluid") %>
+								<%= image_tag(lti_app_icon_url(app[:app_name]), alt: "Icon", size: "35", class: "img-fluid") %>
 							</div>
 							<h5 class="card-title mt-3"><%= app[:app_name] %></h5>
 							


### PR DESCRIPTION
![Screenshot from 2024-04-24 09-44-26](https://github.com/bigbluebutton/bbb-lti-broker/assets/578359/1fefe27b-9fa9-4ed9-8246-492c190f3505)
